### PR TITLE
Using Serverless CLI or Env variables to set tracing value

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,13 @@ module.exports = class TracingConfigPlugin {
    processTracing() {
      const service = this.serverless.service;
      const stage = this.options.stage;
-     const providerLevelTracingEnabled = (service.provider.tracing === true);
+     const providerLevelTracingEnabled = (service.provider.tracing === true || service.provider.tracing === 'true');
      return Promise.all(Object.keys(service.functions).map(functionName => {
         return this.toggleTracing(
           service.functions[functionName].name || `${service.service}-${stage}-${functionName}`,
-          (service.functions[functionName].tracing === true)
-          || (providerLevelTracingEnabled && service.functions[functionName].tracing !== false)
+          service.functions[functionName].tracing === true
+          || service.functions[functionName].tracing === 'true'
+          || (providerLevelTracingEnabled && (service.functions[functionName].tracing !== false && service.functions[functionName].tracing !== 'false'))
         );
      }));
   }

--- a/test/test.js
+++ b/test/test.js
@@ -187,4 +187,33 @@ describe('serverless-plugin-tracing', function() {
       }
     ]);
   });
+
+  it('enables tracing when opt variable is "true"', function() {
+    runPlugin({
+      functions: {
+        healthcheck: {
+          tracing: 'false'
+        },
+        mainFunction: {
+          tracing: 'true'
+        }
+      },
+      provider: {
+        tracing: 'true'
+      }
+    });
+
+    assert.deepEqual(logSpy.getCall(0).args[0], 'Tracing DISABLED for function "myService-test-healthcheck"');
+    assert.deepEqual(logSpy.getCall(1).args[0], 'Tracing ENABLED for function "myService-test-mainFunction"');
+    assert.deepEqual(requestSpy.getCall(1).args, [
+      'Lambda',
+      'updateFunctionConfiguration',
+      {
+        FunctionName: 'myService-test-mainFunction',
+        TracingConfig: {
+          Mode: 'Active'
+        }
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
When using `${opt:__variable__, env:__variable__}` in the `serverless.yml` file, this plugin won't evaluate correctly as they are strings.

This PR fixes #7 by checking if tracing is a string value or boolean.