### PR TITLE
Healthcheck value is unnecessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ plugins:
 functions:
   mainFunction: # inherits tracing settings from "provider"
     handler: src/app/index.handler
-  healthcheck:
     tracing: false # overrides provider settings (opt out)
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ plugins:
 functions:
   mainFunction: # inherits tracing settings from "provider"
     handler: src/app/index.handler
+  healthCheckFunction:
     tracing: false # overrides provider settings (opt out)
 ```
 


### PR DESCRIPTION
You check for `tracing` value and not `healthcheck` > `tracing` in your code, so removing `healthcheck` fixes the example.